### PR TITLE
Add valid-package-file-require rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Add `mediawiki` to the plugins section of your `.eslintrc` configuration file, t
 }
 ```
 
+## Rules
+* `mediawiki/msg-doc` - Ensures message keys are documented when they are constructed.
+* `mediawiki/valid-package-file-require`- Ensures `require`d files are in the format that is expected within [ResourceLoader package modules](https://www.mediawiki.org/wiki/ResourceLoader/Package_modules), i.e. contain the file extension and are proper relative paths, e.g. `./foo.js` instead of `./foo` or `foo.js`.
+
 ## Development
 
 ```sh

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	rules: {
-		'msg-doc': require( './rules/msg-doc.js' )
+		'msg-doc': require( './rules/msg-doc.js' ),
+		'valid-package-file-require': require( './lib/rules/valid-package-file-require' )
 	}
 };

--- a/rules/valid-package-file-require.js
+++ b/rules/valid-package-file-require.js
@@ -1,0 +1,49 @@
+const path = require( 'path' );
+
+function dotSlashPrefixIfMissing( fileName ) {
+	return fileName.indexOf( '.' ) !== 0 ? `./${fileName}` : fileName;
+}
+
+function getFullRelativeFilePath( name, context ) {
+	const contextDirPath = path.dirname( context.getFilename() );
+	const absolutePath = require.resolve(
+		// `require( 'foo.js' )` will be resolved in older node version, whereas for newer ones
+		// it should always be `require( './foo.js' )` for files in the same directory.
+		// => always prefix with './'
+		dotSlashPrefixIfMissing( name ),
+		{ paths: [ contextDirPath ] }
+	);
+	const relativePath = path.relative( contextDirPath, absolutePath );
+
+	return dotSlashPrefixIfMissing( relativePath );
+}
+
+module.exports = {
+	meta: {
+		messages: {
+			badFilePath: 'bad resource loader package file path'
+		}
+	},
+
+	create: function ( context ) {
+		return {
+			CallExpression: ( node ) => {
+				if ( node.callee.name !== 'require' || !node.arguments.length ) {
+					return;
+				}
+
+				const requiredFileOrModule = node.arguments[ 0 ].value;
+				let fullRelativeFilePath;
+				try {
+					fullRelativeFilePath = getFullRelativeFilePath( requiredFileOrModule, context );
+				} catch ( e ) {
+					return; // not a file path, probably a RL module. All good!
+				}
+
+				if ( requiredFileOrModule !== fullRelativeFilePath ) {
+					context.report( { node, messageId: 'badFilePath' } );
+				}
+			}
+		};
+	}
+};

--- a/tests/valid-package-file-require.js
+++ b/tests/valid-package-file-require.js
@@ -1,0 +1,36 @@
+const rule = require( '../rules/valid-package-file-require' );
+const path = require( 'path' );
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester();
+const testFileName = path.resolve( __dirname + '/sandbox/test.js' );
+
+ruleTester.run( 'valid-package-file-require', rule, {
+	valid: [
+		{
+			code: 'var foo = require( \'./foo.js\' );',
+			filename: testFileName
+		},
+		{
+			code: 'var bar = require( \'bar\' );',
+			filename: testFileName
+		}
+	],
+
+	invalid: [
+		{
+			code: 'var foo = require( \'./foo\' );',
+			filename: testFileName,
+			errors: [
+				{ message: 'bad resource loader package file path' }
+			]
+		},
+		{
+			code: 'var foo = require( \'foo.js\' );',
+			filename: testFileName,
+			errors: [
+				{ message: 'bad resource loader package file path' }
+			]
+		}
+	]
+} );


### PR DESCRIPTION
This adds a rule that ensures file paths passed to `require` are valid
within the context of package modules. These can differ from files paths
commonly used in CommonJS modules in that they require the file
extension at the end, and need the `./` prefix for files that are
required from the same directory or farther down in the directory
structure.

This is especially useful for code that is written to be compatible both in a ResourceLoader context and in a webpack or node, such as https://github.com/wmde/WikibaseDataModelJavaScript.