### PR TITLE
Bump version to 0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-mediawiki",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-mediawiki",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "MediaWiki-specific linting rules, for use in MediaWiki core and extensions.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
* added `mediawiki/valid-package-file-require` rule

---

It would be great if we could get the new version released soon so we can install this package from npm and use the `mediawiki/valid-package-file-require` rule :)