### PR TITLE
Fix `valid-package-file-require` file path in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@
 module.exports = {
 	rules: {
 		'msg-doc': require( './rules/msg-doc.js' ),
-		'valid-package-file-require': require( './lib/rules/valid-package-file-require' )
+		'valid-package-file-require': require( './rules/valid-package-file-require.js' )
 	}
 };


### PR DESCRIPTION
Sloppy copy & paste from https://github.com/wmde/eslint-plugin-resource-loader which has a different directory structure. Sorry!