### PR TITLE
Create rule for documenting constructed CSS classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add `mediawiki` to the plugins section of your `.eslintrc` configuration file, t
 ```
 
 ## Rules
+* `mediawiki/class-doc` - Ensures CSS classes are documented when they are constructed.
 * `mediawiki/msg-doc` - Ensures message keys are documented when they are constructed.
 * `mediawiki/valid-package-file-require`- Ensures `require`d files are in the format that is expected within [ResourceLoader package modules](https://www.mediawiki.org/wiki/ResourceLoader/Package_modules), i.e. contain the file extension and are proper relative paths, e.g. `./foo.js` instead of `./foo` or `foo.js`.
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	rules: {
+		'class-doc': require( './rules/class-doc.js' ),
 		'msg-doc': require( './rules/msg-doc.js' ),
 		'valid-package-file-require': require( './rules/valid-package-file-require.js' )
 	}

--- a/rules/class-doc.js
+++ b/rules/class-doc.js
@@ -2,13 +2,16 @@
 
 const utils = require( './utils.js' );
 
-// TODO: Support `new mw.Message( store, key )` syntax
-const methodNames = [ 'msg', 'message', 'deferMsg' ];
+// TODO: Support native JS methods:
+// * element.classList.add()/remove()
+// * element.className =
+// * jQuery.attr
+const methodNames = [ 'addClass', 'removeClass', 'toggleClass' ];
 
 module.exports = {
 	meta: {
 		docs: {
-			description: 'Ensures message keys are documented when they are constructed.'
+			description: 'Ensures CSS classes are documented when they are constructed.'
 		},
 		schema: []
 	},
@@ -28,7 +31,7 @@ module.exports = {
 				if ( utils.requiresCommentList( context, node ) ) {
 					context.report( {
 						node: node,
-						message: 'All possible message keys should be documented'
+						message: 'All possible CSS classes should be documented'
 						// TODO: Link to documentation page
 					} );
 				}

--- a/rules/utils.js
+++ b/rules/utils.js
@@ -1,0 +1,59 @@
+function countMessages( sourceCode, node, countedLines ) {
+	const comments = sourceCode.getCommentsInside( node )
+		.concat( sourceCode.getCommentsBefore( node ) );
+	return comments.reduce(
+		function ( acc, line ) {
+			if ( line.type === 'Block' ) {
+				return acc;
+			}
+			let matches;
+			if ( !countedLines.has( line ) ) {
+				matches = line.value.match( /^ *\* ?[a-z]./gi );
+				countedLines.add( line );
+			}
+			return acc + ( matches ? matches.length : 0 );
+		}, 0
+	);
+}
+
+function requiresCommentList( context, node ) {
+	const arg = node.arguments[ 0 ];
+
+	// Allow self-documenting message key uses
+	if (
+		// msg( 'foo' )
+		arg.type === 'Literal' ||
+		// msg( cond ? 'foo' : 'bar' )
+		(
+			arg.type === 'ConditionalExpression' &&
+			arg.consequent.type === 'Literal' &&
+			arg.alternate.type === 'Literal'
+		)
+		// TODO: Support nested ConditionalExpression's?
+	) {
+		return false;
+	}
+
+	const sourceCode = context.getSourceCode();
+	// Don't modify `node` so the correct error source is highlighted
+	let checkNode = node,
+		messages = 0;
+	const countedLines = new Set();
+	while ( checkNode && checkNode.type !== 'ExpressionStatement' ) {
+		messages += countMessages( sourceCode, checkNode, countedLines );
+
+		if ( messages > 1 ) {
+			// Comments found, return
+			return false;
+		}
+
+		// Allow documentation to be on or in parent nodes
+		checkNode = checkNode.parent;
+	}
+
+	return true;
+}
+
+module.exports = {
+	requiresCommentList: requiresCommentList
+};

--- a/tests/class-doc.js
+++ b/tests/class-doc.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const rule = require( '../rules/class-doc' );
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const error = 'All possible CSS classes should be documented';
+
+const ruleTester = new RuleTester();
+ruleTester.run( 'class-doc', rule, {
+	valid: [
+		'// The following classes are used here:\n' +
+		'// * foo-baz\n' +
+		'// * foo-quux\n' +
+		'display( $el.addClass("foo-" + bar), baz )',
+
+		'// The following classes are used here:\n' +
+		'// * foo-baz\n' +
+		'// * foo-quux\n' +
+		'// * foo-whee\n' +
+		'$el.addClass("foo-" + bar)',
+
+		'$foo\n' +
+		'// The following classes are used here:\n' +
+		'// * foo-baz\n' +
+		'// * foo-quux\n' +
+		'.text($el.addClass("foo-" + bar))',
+
+		'$el.addClass(test ? "foo" : "bar")',
+
+		'$el.addClass("foo-bar")',
+
+		'$el.removeClass("foo-bar")',
+
+		'$el.toggleClass("foo-bar")',
+
+		'$el.addClass()'
+	],
+	invalid: [
+		'$el.addClass( "foo-" + bar )',
+
+		// Not enough classes
+		'// This can produce:\n' +
+		'// * foo-bar-baz\n' +
+		'$el.addClass( "foo-" + bar )',
+
+		// Wrong format
+		'// This constructs foo-baz or foo-quux\n' +
+		'$el.addClass( "foo-" + bar )',
+
+		// Block comments are ignored as the extra `*`'s are confusing
+		'/**\n' +
+		' The following classes are used here:\n' +
+		' * foo-baz\n' +
+		' * foo-quux\n' +
+		' */\n' +
+		'display( $el.addClass("foo-" + bar), baz )'
+
+	].map( function ( code ) {
+		return {
+			code: code,
+			errors: [ { message: error, type: 'CallExpression' } ]
+		};
+	} )
+} );


### PR DESCRIPTION
* Moves most of the msg-doc code to a shared utility.
* For now just detects jQuery methods addClass/removeClass/
  toggleClass, which probably covers a large majority of our
  usage.

Fixes #3