### PR TITLE
New rule: no-vue-dynamic-i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Add `mediawiki` to the plugins section of your `.eslintrc` configuration file, t
 * `mediawiki/class-doc` - Ensures CSS classes are documented when they are constructed.
 * `mediawiki/msg-doc` - Ensures message keys are documented when they are constructed.
 * `mediawiki/valid-package-file-require`- Ensures `require`d files are in the format that is expected within [ResourceLoader package modules](https://www.mediawiki.org/wiki/ResourceLoader/Package_modules), i.e. contain the file extension and are proper relative paths, e.g. `./foo.js` instead of `./foo` or `foo.js`.
+* `mediawiki/no-vue-dynamic-i18n` - Ensures that `$i18n()` and `v-i18n-html` are not passed dynamic message keys in Vue templates
 
 ## Development
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
 	rules: {
 		'class-doc': require( './rules/class-doc.js' ),
 		'msg-doc': require( './rules/msg-doc.js' ),
+		'no-vue-dynamic-i18n': require( './rules/no-vue-dynamic-i18n.js' ),
 		'valid-package-file-require': require( './rules/valid-package-file-require.js' )
 	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,23 @@
 			"integrity": "sha512-+0i2xcYryUoLawi47Lp0iJKzkP931G5GXwIOq1KBKQc2pknV1VPjfE6b4mI2mR2RnL7WRoS30YjwC9SjQgJDXQ==",
 			"dev": true
 		},
+		"eslint-plugin-vue": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
+			"integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+			"requires": {
+				"natural-compare": "^1.4.0",
+				"semver": "^5.6.0",
+				"vue-eslint-parser": "^7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
 		"eslint-scope": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -1884,6 +1901,36 @@
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.1.tgz",
 			"integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==",
 			"dev": true
+		},
+		"vue-eslint-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz",
+			"integrity": "sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==",
+			"requires": {
+				"debug": "^4.1.1",
+				"eslint-scope": "^5.0.0",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.2",
+				"esquery": "^1.0.1",
+				"lodash": "^4.17.15"
+			},
+			"dependencies": {
+				"acorn-jsx": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+					"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
+				},
+				"espree": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+					"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+					"requires": {
+						"acorn": "^7.1.1",
+						"acorn-jsx": "^5.2.0",
+						"eslint-visitor-keys": "^1.1.0"
+					}
+				}
+			}
 		},
 		"which": {
 			"version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
 		"index.js",
 		"rules/*"
 	],
+	"dependencies": {
+		"eslint-plugin-vue": "^6.2.2"
+	},
 	"peerDependencies": {
 		"eslint": ">=2.3.0"
 	},
@@ -35,6 +38,5 @@
 	"homepage": "https://github.com/wikimedia/eslint-plugin-mediawiki#readme",
 	"directories": {
 		"test": "tests"
-	},
-	"dependencies": {}
+	}
 }

--- a/rules/no-vue-dynamic-i18n.js
+++ b/rules/no-vue-dynamic-i18n.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const vueUtils = require( 'eslint-plugin-vue/lib/utils' );
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Prohibits dynamic i18n message keys in Vue templates'
+		},
+		messages: {
+			'dynamic-i18n': 'Dynamic message keys should not be used in templates. Use a computed property instead'
+		},
+		schema: []
+	},
+	create( context ) {
+		return vueUtils.defineTemplateBodyVisitor( context, {
+			"VExpressionContainer CallExpression[callee.name='$i18n']"( node ) {
+				if ( node.arguments.length > 0 && node.arguments[ 0 ].type !== 'Literal' ) {
+					context.report( { node, messageId: 'dynamic-i18n' } );
+				}
+			},
+			"VAttribute[directive=true][key.name.name='i18n-html']"( node ) {
+				if ( node.key.argument && node.key.argument.type === 'VExpressionContainer' ) {
+					context.report( { node, messageId: 'dynamic-i18n' } );
+				}
+			}
+		} );
+	}
+};

--- a/tests/no-vue-dynamic-i18n.js
+++ b/tests/no-vue-dynamic-i18n.js
@@ -1,0 +1,45 @@
+const rule = require( '../rules/no-vue-dynamic-i18n' );
+const path = require( 'path' );
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const errorMessage = 'Dynamic message keys should not be used in templates. Use a computed property instead';
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( 'vue-eslint-parser' )
+} );
+const testFileName = path.resolve( __dirname + '/sandbox/test.vue' );
+
+ruleTester.run( 'no-vue-dynamic-i18n', rule, {
+	valid: [
+		"<template><p>{{ $i18n( 'foo' ) }}</p></template>",
+		"<template><p>{{ $i18n( 'foo', param1, param2 ) }}</p></template>",
+		"<template><p>{{ $i18n( 'foo' ).params( [ param1, param2 ] ) }}</p></template>",
+		'<template><p v-i18n-html:message-key /></template>',
+		'<template><p v-i18n-html:message-key="[ param1, param2 ]" /></template>',
+		'<template><p v-i18n-html="msgObj" /></template>',
+		"<template><p v-i18n-html=\"$i18n( 'foo' )\" /></template>",
+		"<template><p v-i18n-html=\"$i18n( 'foo', param1, param2 )\" /></template>",
+		"<template><p v-i18n-html=\"$i18n( 'foo' ).params( [ param1, param2 ] )\" /></template>"
+	].map( ( code ) => ( {
+		code,
+		filename: testFileName
+	} ) ),
+
+	invalid: [
+		'<template><p>{{ $i18n( msgkey ) }}</p></template>',
+		'<template><p>{{ $i18n( msgkey, param1, param2 ) }}</p></template>',
+		'<template><p>{{ $i18n( foo.msgkey ) }}</p></template>',
+		"<template><p>{{ $i18n( 'foo-' + msgkeySuffix ) }}</p></template>",
+		'<template><p v-i18n-html:[msgKey] /></template>',
+		'<template><p v-i18n-html:[msgKey]="[ param1, param2 ]" /></template>',
+		'<template><p v-i18n-html="$i18n( msgkey )" /></template>',
+		'<template><p v-i18n-html="$i18n( msgkey, param1, param2 )" /></template>',
+		'<template><p v-i18n-html="$i18n( msgkey ).params( [ param1, param2 ] )" /></template>'
+	].map( ( code ) => ( {
+		code,
+		filename: testFileName,
+		errors: [
+			{ message: errorMessage }
+		]
+	} ) )
+} );


### PR DESCRIPTION
Forbids anything but a literal from being passed as the first argument
to $i18n() in Vue templates, and also forbids passing a dynamic argument
with v-i18n-html.

Addresses part of #11