### PR TITLE
valid-package-file-require: Check if require() arg looks like a path

### DIFF
--- a/rules/valid-package-file-require.js
+++ b/rules/valid-package-file-require.js
@@ -33,11 +33,18 @@ module.exports = {
 				}
 
 				const requiredFileOrModule = node.arguments[ 0 ].value;
+				// Check if the argument starts with ./ or ../, or ends with .js or .json
+				if ( !requiredFileOrModule.match( /(^\.\.?\/)|(\.(js|json)$)/ ) ) {
+					// If not, it's probably a ResourceLoader module; ignore
+					return;
+				}
+
 				let fullRelativeFilePath;
 				try {
 					fullRelativeFilePath = getFullRelativeFilePath( requiredFileOrModule, context );
 				} catch ( e ) {
-					return; // not a file path, probably a RL module. All good!
+					// File doesn't exist, probably a virtual file in a packageFiles module; ignore
+					return;
 				}
 
 				if ( requiredFileOrModule !== fullRelativeFilePath ) {

--- a/tests/valid-package-file-require.js
+++ b/tests/valid-package-file-require.js
@@ -12,6 +12,18 @@ ruleTester.run( 'valid-package-file-require', rule, {
 			filename: testFileName
 		},
 		{
+			code: 'var foo = require( \'./quux.json\' );',
+			filename: testFileName
+		},
+		{
+			code: 'var bar = require( \'../valid-package-file-require.js\' );',
+			filename: testFileName
+		},
+		{
+			code: 'var foo = require( \'foo\' );',
+			filename: testFileName
+		},
+		{
 			code: 'var bar = require( \'bar\' );',
 			filename: testFileName
 		}
@@ -27,6 +39,20 @@ ruleTester.run( 'valid-package-file-require', rule, {
 		},
 		{
 			code: 'var foo = require( \'foo.js\' );',
+			filename: testFileName,
+			errors: [
+				{ message: 'bad resource loader package file path' }
+			]
+		},
+		{
+			code: 'var foo = require( \'./quux\' );',
+			filename: testFileName,
+			errors: [
+				{ message: 'bad resource loader package file path' }
+			]
+		},
+		{
+			code: 'var foo = require( \'quux.json\' );',
 			filename: testFileName,
 			errors: [
 				{ message: 'bad resource loader package file path' }


### PR DESCRIPTION
If require() is called with an argument that doesn't look like a path,
it's probably a module name, and we should leave it alone.
require('foo') should be allowed, even if 'foo.js' exists.

Only apply this rule if the require() argument looks like a file path,
meaning it either starts with ./ or ../, or ends with .js or .json.

Fixes #17