### PR TITLE
valid-package-file-require: Report correct file path in error message

### DIFF
--- a/rules/valid-package-file-require.js
+++ b/rules/valid-package-file-require.js
@@ -21,7 +21,7 @@ function getFullRelativeFilePath( name, context ) {
 module.exports = {
 	meta: {
 		messages: {
-			badFilePath: 'bad resource loader package file path'
+			badFilePath: 'Incorrect file path in require(): use {{ fullRelativeFilePath }} instead'
 		}
 	},
 
@@ -41,7 +41,7 @@ module.exports = {
 				}
 
 				if ( requiredFileOrModule !== fullRelativeFilePath ) {
-					context.report( { node, messageId: 'badFilePath' } );
+					context.report( { node, messageId: 'badFilePath', data: { fullRelativeFilePath } } );
 				}
 			}
 		};

--- a/tests/valid-package-file-require.js
+++ b/tests/valid-package-file-require.js
@@ -22,14 +22,14 @@ ruleTester.run( 'valid-package-file-require', rule, {
 			code: 'var foo = require( \'./foo\' );',
 			filename: testFileName,
 			errors: [
-				{ message: 'bad resource loader package file path' }
+				{ message: 'Incorrect file path in require(): use ./foo.js instead' }
 			]
 		},
 		{
 			code: 'var foo = require( \'foo.js\' );',
 			filename: testFileName,
 			errors: [
-				{ message: 'bad resource loader package file path' }
+				{ message: 'Incorrect file path in require(): use ./foo.js instead' }
 			]
 		}
 	]


### PR DESCRIPTION
Tell the user what we expect them to do, rather than just saying their
path is bad and they should feel bad.