### PR TITLE
Update ESLint peerDependecy to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"eslint-plugin-vue": "^6.2.2"
 	},
 	"peerDependencies": {
-		"eslint": ">=2.3.0"
+		"eslint": ">=5.0.0"
 	},
 	"devDependencies": {
 		"eslint": "^6.4.0",


### PR DESCRIPTION
This is the same as eslint-plugin-vue@6.2.2. As this plugin
should only really be used with eslint-config-wikimedia,
which requires 6.8.0, this should not be much of an issue.

Also without fixes the claimed support for ESLint 5 is a lie.