### PR TITLE
msg-doc / class-doc: Fix behavior in var statements

### DIFF
--- a/docs/rules/msg-doc.md
+++ b/docs/rules/msg-doc.md
@@ -27,6 +27,40 @@ message = mw.msg( 'foo-' + bar );
  * foo-quux
  */
 display( mw.msg( 'foo-' + bar ), baz );
+
+function foo() {
+    const first = mw.msg( 'foo-' + baz ),
+        // This can produce:
+        // * bar-x
+        // * bar-y
+        second = mw.msg( 'bar-' + baz );
+}
+
+function foo() {
+    const
+        // This can produce:
+        // * foo-x
+        // * foo-y
+        first = mw.msg( 'foo-' + baz ),
+        second = mw.msg( 'bar-' + baz );
+}
+
+function foo() {
+    // This can produce:
+    // * foo-x
+    // * foo-y
+    const first = mw.msg( 'foo-' + baz ),
+        second = mw.msg( 'bar-' + baz );
+}
+
+function foo() {
+    let first = mw.msg( 'foo-' + baz ), second;
+    bar.quux();
+    // This can produce:
+    // * bar-x
+    // * bar-y
+    second = mw.msg( 'bar-' + baz );
+}
 ```
 
 ✔️ Examples of **correct** code:
@@ -48,6 +82,29 @@ $foo
     // * foo-baz
     // * foo-quux
     .text( mw.msg( 'foo-' + bar ) );
+
+function foo() {
+    const
+        // This can produce:
+        // * foo-x
+        // * foo-y
+        first = mw.msg( 'foo-' + baz ),
+        // This can produce:
+        // * bar-x
+        // * bar-y
+        second = mw.msg( 'bar-' + baz );
+}
+
+function foo() {
+    // This can produce:
+    // * foo-x
+    // * foo-y
+    const first = mw.msg( 'foo-' + baz ),
+        // This can produce:
+        // * bar-x
+        // * bar-y
+        second = mw.msg( 'bar-' + baz );
+}
 
 message = mw.msg( test ? 'foo' : 'bar' );
 message = mw.msg( test ? ( test2 ? 'foo' : 'bar' ) : ( test2 ? 'baz' : 'quux' ) );

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
-function countListItems( sourceCode, node, countedLines ) {
-	const comments = sourceCode.getCommentsInside( node )
+function countListItems( sourceCode, node, countedLines, onlyBefore ) {
+	const comments = ( onlyBefore ? [] : sourceCode.getCommentsInside( node ) )
 		.concat( sourceCode.getCommentsBefore( node ) );
 	return comments.reduce(
 		function ( acc, line ) {
@@ -41,9 +41,14 @@ function requiresCommentList( context, node ) {
 	const sourceCode = context.getSourceCode();
 	// Don't modify `node` so the correct error source is highlighted
 	let checkNode = node,
+		prevNode = node,
 		listItems = 0;
 	const countedLines = new Set();
-	while ( checkNode && checkNode.type !== 'ExpressionStatement' ) {
+	while (
+		checkNode &&
+		checkNode.type !== 'ExpressionStatement' &&
+		checkNode.type !== 'VariableDeclaration'
+	) {
 		listItems += countListItems( sourceCode, checkNode, countedLines );
 
 		if ( listItems > 1 ) {
@@ -52,7 +57,18 @@ function requiresCommentList( context, node ) {
 		}
 
 		// Allow documentation to be on or in parent nodes
+		prevNode = checkNode;
 		checkNode = checkNode.parent;
+	}
+
+	// Allow documentation for the first VariableDeclarator in a VariableDeclaration to be
+	// above the VariableDeclaration. But don't look inside the VariableDeclaration, because that
+	// would allow the documentation for a different variable to be counted.
+	if ( checkNode.type === 'VariableDeclaration' && checkNode.declarations[ 0 ] === prevNode ) {
+		listItems += countListItems( sourceCode, checkNode, countedLines, true );
+		if ( listItems > 1 ) {
+			return false;
+		}
 	}
 
 	return true;

--- a/tests/rules/msg-doc.js
+++ b/tests/rules/msg-doc.js
@@ -142,8 +142,7 @@ ruleTester.run( 'msg-doc', rule, {
 			// * bar-x
 			// * bar-y
 			second = mw.msg( 'bar-' + baz );
-		}
-		`
+		}`
 
 	].map( function ( code ) {
 		return {

--- a/tests/rules/msg-doc.js
+++ b/tests/rules/msg-doc.js
@@ -29,6 +29,33 @@ ruleTester.run( 'msg-doc', rule, {
 			// * foo-quux
 			.text(mw.msg("foo-" + bar))`,
 
+		// The comment for the first variable declaration may be inside the var statement...
+		outdent`
+		function foo() {
+			var
+				// This can produce:
+				// * foo-x
+				// * foo-y
+				first = mw.msg( 'foo-' + baz ),
+				// This can produce:
+				// * bar-x
+				// * bar-y
+				second = mw.msg( 'bar-' + baz );
+		}`,
+
+		// ...or above the var statement
+		outdent`
+		function foo() {
+			// This can produce:
+			// * foo-x
+			// * foo-y
+			var first = mw.msg( 'foo-' + baz ),
+				// This can produce:
+				// * bar-x
+				// * bar-y
+				second = mw.msg( 'bar-' + baz );
+		}`,
+
 		'message = mw.msg(test ? "foo" : "bar")',
 
 		'message = mw.msg(test ? (test2 ? "foo" : "bar") : (test2 ? "baz" : "quux"))',
@@ -73,7 +100,50 @@ ruleTester.run( 'msg-doc', rule, {
 		 * foo-baz
 		 * foo-quux
 		 */
-		display( mw.msg("foo-" + bar), baz )`
+		display( mw.msg("foo-" + bar), baz )`,
+
+		// A comment for the second variable does not count for the first variable
+		outdent`
+		function foo() {
+			var first = mw.msg( 'foo-' + baz ),
+				// This can produce:
+				// * bar-x
+				// * bar-y
+				second = mw.msg( 'bar-' + baz );
+		}`,
+
+		// A comment for the first variable does not count for the second variable
+		outdent`
+		function foo() {
+			var
+				// This can produce:
+				// * foo-x
+				// * foo-y
+				first = mw.msg( 'foo-' + baz ),
+				second = mw.msg( 'bar-' + baz );
+		}`,
+
+		// A comment above the var statement only counts for the first variable, not the second
+		outdent`
+		function foo() {
+			// This can produce:
+			// * foo-x
+			// * foo-y
+			var first = mw.msg( 'foo-' + baz ),
+				second = mw.msg( 'bar-' + baz );
+		}`,
+
+		// A comment elsewhere in the function does not count for a variable declaration
+		outdent`
+		function foo() {
+			var first = mw.msg( 'foo-' + baz ), second;
+			bar.quux();
+			// This can produce:
+			// * bar-x
+			// * bar-y
+			second = mw.msg( 'bar-' + baz );
+		}
+		`
 
 	].map( function ( code ) {
 		return {


### PR DESCRIPTION
Fixes #53. See issue for a detailed overview of the problem.

var statements are VariableDeclarations, and don't contain an
ExpressionStatement. The loop traversing up until it hit an
ExpressionStatement would traverse up way too far, and count list
comments anywhere in the method (or sometimes, anywhere in the *file*)
as documentation for a variable declaration.

Fix this by stopping traversal when we hit a VariableDeclaration.

Unfortunately, a comment right above a var statement doesn't count as
being "before" the first VariableDeclarator, only as being before the
VariableDeclaration. To prevent people from having to write stuff like

    var
        // * foo-23
        // * foo-42
        baz = mw.msg( 'foo-' + bar );

also allow comments before the VariableDeclaration to count, but only
for the first variable. This allows for cleaner code like:

    // * foo-23
    // * foo-42
    var baz = mw.msg( 'foo-' + bar );