### PR TITLE
valid-package-file-require: also support vue

### DIFF
--- a/src/rules/valid-package-file-require.js
+++ b/src/rules/valid-package-file-require.js
@@ -51,8 +51,8 @@ module.exports = {
 				}
 
 				const requiredFileOrModule = node.arguments[ 0 ].value;
-				// Check if the argument starts with ./ or ../, or ends with .js or .json
-				if ( !requiredFileOrModule.match( /(^\.\.?\/)|(\.(js|json)$)/ ) ) {
+				// Check if the argument starts with ./ or ../, or ends with .js, .json, or .vue
+				if ( !requiredFileOrModule.match( /(^\.\.?\/)|(\.(js|json|vue)$)/ ) ) {
 					// If not, it's probably a ResourceLoader module; ignore
 					return;
 				}


### PR DESCRIPTION
The current rule was only matching `require` calls starting with `./` or `../` or ending with `.js` or `.json`, but it should also apply to requiring vue files, which can be `require`d since March 2020 (see https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/ca46126e98098ca06d09c541833949fd025b15d7 and https://phabricator.wikimedia.org/T241180)