### PR TITLE
Support eslint-plugin-json-es parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"eslint-config-wikimedia": "^0.20.0",
 				"eslint-docgen": "^0.6.1",
 				"eslint-plugin-eslint-plugin": "^3.6.1",
+				"eslint-plugin-json-es": "^1.5.4",
 				"mocha": "^9.1.2",
 				"nyc": "^15.1.0",
 				"outdent": "^0.8.0"
@@ -1477,16 +1478,51 @@
 			}
 		},
 		"node_modules/eslint-plugin-json-es": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-json-es/-/eslint-plugin-json-es-1.5.3.tgz",
-			"integrity": "sha512-9wWjwhoN+ipMel70ktkWy0H7jj9sm5OAbAy3N3F3AT0swpIofVsIjDXyjGZJwSzy9tZzDtI/aKIj2WsqMHw2QA==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-json-es/-/eslint-plugin-json-es-1.5.4.tgz",
+			"integrity": "sha512-DdjnNMUZ1iMrUXfxUQrTU7IyoEOsa4Kg0Zd6nOyOq1mUb75deK7NrcbI1FlWGdGVgqX99bUOD27i81EYiG794Q==",
 			"dev": true,
 			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0",
-				"espree": "^7.3.1"
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0"
 			},
 			"peerDependencies": {
 				"eslint": ">= 7"
+			}
+		},
+		"node_modules/eslint-plugin-json-es/node_modules/acorn": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/eslint-plugin-json-es/node_modules/eslint-visitor-keys": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+			"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-json-es/node_modules/espree": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+			"integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.5.0",
+				"acorn-jsx": "^5.3.1",
+				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-mediawiki": {
@@ -5630,13 +5666,38 @@
 			}
 		},
 		"eslint-plugin-json-es": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-json-es/-/eslint-plugin-json-es-1.5.3.tgz",
-			"integrity": "sha512-9wWjwhoN+ipMel70ktkWy0H7jj9sm5OAbAy3N3F3AT0swpIofVsIjDXyjGZJwSzy9tZzDtI/aKIj2WsqMHw2QA==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-json-es/-/eslint-plugin-json-es-1.5.4.tgz",
+			"integrity": "sha512-DdjnNMUZ1iMrUXfxUQrTU7IyoEOsa4Kg0Zd6nOyOq1mUb75deK7NrcbI1FlWGdGVgqX99bUOD27i81EYiG794Q==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^2.0.0",
-				"espree": "^7.3.1"
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+					"dev": true
+				},
+				"eslint-visitor-keys": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+					"integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+					"dev": true
+				},
+				"espree": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+					"integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+					"dev": true,
+					"requires": {
+						"acorn": "^8.5.0",
+						"acorn-jsx": "^5.3.1",
+						"eslint-visitor-keys": "^3.0.0"
+					}
+				}
 			}
 		},
 		"eslint-plugin-mediawiki": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"eslint-config-wikimedia": "^0.20.0",
 		"eslint-docgen": "^0.6.1",
 		"eslint-plugin-eslint-plugin": "^3.6.1",
+		"eslint-plugin-json-es": "^1.5.4",
 		"mocha": "^9.1.2",
 		"nyc": "^15.1.0",
 		"outdent": "^0.8.0"

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,6 +61,13 @@ function requiresCommentList( context, node ) {
 		checkNode = checkNode.parent;
 	}
 
+	// In custom parsers (e.g. eslint-plugin-json-es) we can reach the top
+	// of the tree. If this happens, don't report any errors.
+	// https://github.com/wikimedia/eslint-plugin-mediawiki/issues/59
+	if ( !checkNode ) {
+		return false;
+	}
+
 	// Allow documentation for the first VariableDeclarator in a VariableDeclaration to be
 	// above the VariableDeclaration. But don't look inside the VariableDeclaration, because that
 	// would allow the documentation for a different variable to be counted.

--- a/tests/rules/class-doc.js
+++ b/tests/rules/class-doc.js
@@ -90,6 +90,13 @@ ruleTester.run( 'class-doc', rule, {
 		{
 			code: 'new OO.ui.ButtonWidget( { framed: false, ...config } )',
 			docgen: false
+		},
+
+		// JSON input
+		{
+			code: '{ "classes": { "foo": "bar" } }',
+			parser: require.resolve( 'eslint-plugin-json-es' ),
+			docgen: false
 		}
 	],
 	invalid: (


### PR DESCRIPTION
Ideally this rule shouldn't be run on JSON input,
but it doesn't hurt to not throw an exception.

Fixes #59
