### PR TITLE
msg-doc: Update short URL to help page

### DIFF
--- a/src/rules/msg-doc.js
+++ b/src/rules/msg-doc.js
@@ -4,8 +4,8 @@ const utils = require( '../utils.js' );
 
 // TODO: Support `new mw.Message( store, key )` syntax
 const methodNames = [ 'msg', 'message', 'deferMsg' ];
-// Links to https://www.mediawiki.org/wiki/Special:MyLanguage/Localisation#Using_messages
-const message = 'All possible message keys should be documented. See https://w.wiki/PRw for details.';
+// Links to https://www.mediawiki.org/wiki/Special:MyLanguage/Help:System_message#Using_messages
+const message = 'All possible message keys should be documented. See https://w.wiki/4r9a for details.';
 
 module.exports = {
 	meta: {

--- a/tests/rules/msg-doc.js
+++ b/tests/rules/msg-doc.js
@@ -4,7 +4,7 @@ const rule = require( '../../src/rules/msg-doc' );
 const RuleTester = require( 'eslint-docgen' ).RuleTester;
 const outdent = require( 'outdent' );
 
-const error = 'All possible message keys should be documented. See https://w.wiki/PRw for details.';
+const error = 'All possible message keys should be documented. See https://w.wiki/4r9a for details.';
 
 const ruleTester = new RuleTester();
 ruleTester.run( 'msg-doc', rule, {


### PR DESCRIPTION
In December 2021 the 'Using messages' section was moved to a new page on
MediaWiki.org: https://www.mediawiki.org/wiki/Special:Diff/4953163

Old URL:

* https://www.mediawiki.org/wiki/Special:MyLanguage/Localisation#Using_messages
* https://w.wiki/PRw

New URL:

* https://www.mediawiki.org/wiki/Special:MyLanguage/Help:System_message#Using_messages
* https://w.wiki/4r9a