### PR TITLE
vue-exports-component-directive: Recognize defineComponent()

### DIFF
--- a/docs/rules/vue-exports-component-directive.md
+++ b/docs/rules/vue-exports-component-directive.md
@@ -32,6 +32,13 @@ module.exports = {};
 <script>
 module.exports = {};
 // @vue/component
+</script>;
+
+<template>
+    <p>Placeholder...</p>
+</template>
+<script>
+module.exports = notDefineComponent( {} );
 </script>
 ```
 
@@ -51,6 +58,28 @@ module.exports = {};
 <script>
 /* @vue/component */
 module.exports = {};
+</script>;
+
+<template>
+    <p>Placeholder...</p>
+</template>
+<script>
+module.exports = defineComponent( {} );
+</script>;
+
+<template>
+    <p>Placeholder...</p>
+</template>
+<script>
+// @vue/component
+module.exports = exports = {};
+</script>;
+
+<template>
+    <p>Placeholder...</p>
+</template>
+<script>
+module.exports = exports = defineComponent( {} );
 </script>;
 
 <template>

--- a/src/rules/vue-exports-component-directive.js
+++ b/src/rules/vue-exports-component-directive.js
@@ -43,6 +43,28 @@ module.exports = {
 					return;
 				}
 
+				// Look at what comes after `module.exports =`, skipping over `exports =` if present
+				let assignedValue = node.right;
+				if ( assignedValue.type === 'AssignmentExpression' &&
+					assignedValue.operator === '=' &&
+					assignedValue.left.type === 'Identifier' &&
+					assignedValue.left.name === 'exports'
+				) {
+					assignedValue = assignedValue.right;
+				}
+
+				// Check if what comes after `module.exports =` is a defineComponent() call
+				if (
+					assignedValue.type === 'CallExpression' &&
+					assignedValue.callee.type === 'Identifier' &&
+					assignedValue.callee.name === 'defineComponent'
+				) {
+					// We have module.exports = defineComponent( ... ) or
+					// module.exports = exports = defineComponent( ... ), so no directive comment
+					// is needed
+					return;
+				}
+
 				// Get all the comments that match the directive, the same way that
 				// eslint-plugin-vue does
 				const commentTokens = context.getSourceCode()

--- a/tests/rules/vue-exports-component-directive.js
+++ b/tests/rules/vue-exports-component-directive.js
@@ -33,6 +33,11 @@ ruleTester.run( 'vue-exports-component-directive', rule, {
 		// Correctly using the directive (both types of comments work)
 		{ code: makeVueFileContent( '// @vue/component\nmodule.exports = {};' ), filename: vueFileName },
 		{ code: makeVueFileContent( '/* @vue/component */\nmodule.exports = {};' ), filename: vueFileName },
+		// Using defineComponent without a directive
+		{ code: makeVueFileContent( 'module.exports = defineComponent( {} );' ), filename: vueFileName },
+		// Using module.exports = exports = ...
+		{ code: makeVueFileContent( '// @vue/component\nmodule.exports = exports = {};' ), filename: vueFileName },
+		{ code: makeVueFileContent( 'module.exports = exports = defineComponent( {} );' ), filename: vueFileName },
 		// Not a Vue file. Don't show this in the docs because its unclear from the output
 		// that its non a Vue file
 		{ code: 'module.exports = {};', filename: jsFileName, docgen: false },
@@ -48,6 +53,8 @@ ruleTester.run( 'vue-exports-component-directive', rule, {
 		// Directive is on the wrong line (one line too high)
 		{ code: makeVueFileContent( '// @vue/component\n\nmodule.exports = {};' ), filename: vueFileName, errors: [ errorMessage ] },
 		// Directive is on the wrong line (after the module.exports)
-		{ code: makeVueFileContent( 'module.exports = {};\n// @vue/component' ), filename: vueFileName, errors: [ errorMessage ] }
+		{ code: makeVueFileContent( 'module.exports = {};\n// @vue/component' ), filename: vueFileName, errors: [ errorMessage ] },
+		// Calling a function that is not defineComponent
+		{ code: makeVueFileContent( 'module.exports = notDefineComponent( {} );' ), filename: vueFileName, errors: [ errorMessage ] }
 	]
 } );


### PR DESCRIPTION
When module.exports = defineComponent( ... ); is used, eslint-plugin-vue
does not need a // @vue/component comment to recognize that the object
is a component definition, so our vue-exports-component-directive rule
shouldn't insist on adding that comment.

Fixes #83