### PR TITLE
Disallow $i18n calls with dynamic arguments without documentation

### DIFF
--- a/src/rules/msg-doc.js
+++ b/src/rules/msg-doc.js
@@ -3,7 +3,7 @@
 const utils = require( '../utils.js' );
 
 // TODO: Support `new mw.Message( store, key )` syntax
-const methodNames = [ 'msg', 'message', 'deferMsg' ];
+const methodNames = [ 'msg', 'message', 'deferMsg', '$i18n' ];
 // Links to https://www.mediawiki.org/wiki/Special:MyLanguage/Help:System_message#Using_messages
 const message = 'All possible message keys should be documented. See https://w.wiki/4r9a for details.';
 

--- a/tests/rules/msg-doc.js
+++ b/tests/rules/msg-doc.js
@@ -29,6 +29,12 @@ ruleTester.run( 'msg-doc', rule, {
 			// * foo-quux
 			.text(mw.msg("foo-" + bar))`,
 
+		outdent`
+		// The following messages are used here:
+		// * foo-baz
+		// * foo-quux
+		this.$i18n("foo-" + bar)`,
+
 		// The comment for the first variable declaration may be inside the var statement...
 		outdent`
 		function foo() {
@@ -74,6 +80,7 @@ ruleTester.run( 'msg-doc', rule, {
 		'message = mw.msg( "foo-" + bar )',
 
 		'message = mw.msg( cond ? "baz" : "foo-" + bar )',
+		'message = this.$i18n( "foo-" + bar )',
 
 		// Not enough messages
 		outdent`


### PR DESCRIPTION
If I am not wrong, it should fix the rest of #11

Indeed, [mediawiki/no-vue-dynamic-i18n](https://github.com/wikimedia/eslint-plugin-mediawiki/blob/master/docs/rules/no-vue-dynamic-i18n.md) is meant to inspect vue directives. But the plugin lacks the inspection to `$i18n` calls in pure javascript (i.e. in `<script>` tags).

I reuse the `msg-doc` directive as it contains already all the logic, despite the naming not being accurate anymore.

With the hope it can help. Feedback welcome!