### PR TITLE
ci: bump actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,7 +31,7 @@ jobs:
         CI: true
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: ${{ (github.event.pull_request.head.repo.full_name == github.repository) }}
+      if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.lcov

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,7 +31,6 @@ jobs:
         CI: true
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
-      if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.lcov

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,6 +31,7 @@ jobs:
         CI: true
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
+      if: ${{ (github.event.pull_request.head.repo.full_name == github.repository) }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.lcov

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,6 +34,6 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.lcov
-        flgas: unittests
+        flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Turn off autocrlf for Windows testing
       run: |
         git config --global core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
@@ -30,10 +30,10 @@ jobs:
       env:
         CI: true
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.lcov
+        files: ./coverage.lcov
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true


### PR DESCRIPTION
This PR:
- bumps `actions/checkout` from `v2` to `v6`
- bumps `actions/setup-node` from `v1` to `v6`
- bumps `codecov/codecov-action` from `v1` to `v5` and updates action input accordingly