### PR TITLE
Rule fix: `class-doc`/`msg-doc`: Allow simple expressions

### DIFF
--- a/docs/rules/class-doc.md
+++ b/docs/rules/class-doc.md
@@ -11,7 +11,7 @@ Ensures CSS classes are documented when they are constructed.
 ❌ Examples of **incorrect** code:
 ```js
 $el.addClass( 'foo-' + bar );
-$el.addClass( [ 'foo', bar ] );
+$el.addClass( bar + baz );
 
 // This can produce:
 // * foo-bar-baz
@@ -58,12 +58,15 @@ $foo
     .text( $el.addClass( 'foo-' + bar ) );
 
 $el.addClass( test ? 'foo' : 'bar' );
+$el.addClass( className );
 $el.addClass( 'foo-bar' );
 $el.removeClass( 'foo-bar' );
 $el.toggleClass( 'foo-bar' );
 $el.toggleClass( 'foo-bar', foo || bar );
 $el.addClass( [ 'foo', 'bar' ] );
+$el.addClass( [ 'foo', bar ] );
 element.className = 'foo';
+element.className = someClass;
 element.className = cond ? 'foo' : 'bar';
 element.classList.add( 'foo', 'bar' );
 element.classList.remove( 'foo', 'bar' );
@@ -74,6 +77,7 @@ object.property.add( 'foo' + bar );
 foo( 'bar' ).add( 'foo' + bar );
 add( 'foo' + bar );
 new OO.ui.ButtonWidget( { classes: [ 'foo' ] } );
+new OO.ui.ButtonWidget( { classes: dynamicClasses } );
 new OO.ui.ButtonWidget( { classes: [ 'foo', enabled ? 'enabled' : 'disabled' ] } );
 new OO.ui.ButtonWidget( { classes: enabled ? [ 'foo', 'bar' ] : [ 'baz', 'quux' ] } );
 new OO.ui.ButtonWidget( { classes: enabled ? ( framed ? 'ef' : 'eu' ) : ( framed ? 'df' : 'du' ) } );

--- a/docs/rules/msg-doc.md
+++ b/docs/rules/msg-doc.md
@@ -11,6 +11,8 @@ Ensures message keys are documented when they are constructed.
 ❌ Examples of **incorrect** code:
 ```js
 message = mw.msg( 'foo-' + bar );
+message = mw.msg( bar + baz );
+message = mw.msg( key += suffix );
 message = mw.msg( cond ? 'baz' : 'foo-' + bar );
 message = new mw.Message( cond ? 'baz' : 'foo-' + bar );
 message = this.$i18n( 'foo-' + bar );
@@ -122,6 +124,9 @@ function foo() {
 new mw.Message( 'foo-' + baz );
 
 message = mw.msg( test ? 'foo' : 'bar' );
+message = mw.msg( key );
+message = mw.msg( config.key );
+message = new mw.Message( key );
 message = mw.msg( test ? ( test2 ? 'foo' : 'bar' ) : ( test2 ? 'baz' : 'quux' ) );
 message = mw.msg( 'foo-bar' );
 message = mw.message( 'foo-bar' ).plain();

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,8 +33,46 @@ function isOfLiterals( node ) {
 	return false;
 }
 
+function containsStringConcatenation( node ) {
+	if ( node.type === 'BinaryExpression' && node.operator === '+' ) {
+		return true;
+	}
+
+	if ( node.type === 'AssignmentExpression' && node.operator === '+=' ) {
+		return true;
+	}
+
+	// Traverse tree
+	for ( const key of Object.keys( node ) ) {
+		if ( key === 'parent' ) {
+			// Descend only
+			continue;
+		}
+		const value = node[ key ];
+		if ( Array.isArray( value ) ) {
+			for ( const child of value ) {
+				if ( child && typeof child === 'object' && containsStringConcatenation( child ) ) {
+					return true;
+				}
+			}
+		} else if ( value && typeof value === 'object' && typeof value.type === 'string' ) {
+			if ( containsStringConcatenation( value ) ) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 function requiresCommentList( context, node ) {
 	if ( isOfLiterals( node ) ) {
+		return false;
+	}
+
+	// Most expressions don't contain string concatenation, so
+	// only warn if we see explicit inline concatenation.
+	if ( !containsStringConcatenation( node ) ) {
 		return false;
 	}
 
@@ -59,13 +97,6 @@ function requiresCommentList( context, node ) {
 		// Allow documentation to be on or in parent nodes
 		prevNode = checkNode;
 		checkNode = checkNode.parent;
-	}
-
-	// In custom parsers (e.g. eslint-plugin-json-es) we can reach the top
-	// of the tree. If this happens, don't report any errors.
-	// https://github.com/wikimedia/eslint-plugin-mediawiki/issues/59
-	if ( !checkNode ) {
-		return false;
 	}
 
 	// Allow documentation for the first VariableDeclarator in a VariableDeclaration to be

--- a/tests/rules/class-doc.js
+++ b/tests/rules/class-doc.js
@@ -34,6 +34,7 @@ ruleTester.run( 'class-doc', rule, {
 			.text($el.addClass("foo-" + bar))`,
 
 		'$el.addClass(test ? "foo" : "bar")',
+		'$el.addClass( className )',
 		'$el.addClass("foo-bar")',
 		'$el.removeClass("foo-bar")',
 		'$el.toggleClass("foo-bar")',
@@ -41,6 +42,7 @@ ruleTester.run( 'class-doc', rule, {
 
 		// Undocumented feature of jQuery methods:
 		'$el.addClass(["foo", "bar"])',
+		'$el.addClass(["foo", bar])',
 		{
 			code: '$el.addClass()',
 			docgen: false
@@ -48,6 +50,7 @@ ruleTester.run( 'class-doc', rule, {
 
 		// == DOM:className ==
 		'element.className = "foo"',
+		'element.className = someClass',
 		{
 			code: 'element["className"] = "foo"',
 			docgen: false
@@ -70,6 +73,7 @@ ruleTester.run( 'class-doc', rule, {
 
 		// == OOUI ==
 		'new OO.ui.ButtonWidget( { classes: ["foo"] } )',
+		'new OO.ui.ButtonWidget( { classes: dynamicClasses } )',
 
 		{
 			code: 'new OO.ui.ButtonWidget( { "classes": ["foo"] } )',
@@ -105,7 +109,7 @@ ruleTester.run( 'class-doc', rule, {
 		[
 			// == jQuery ==
 			'$el.addClass( "foo-" + bar )',
-			'$el.addClass( ["foo", bar] )',
+			'$el.addClass( bar + baz )',
 
 			// Not enough classes
 			outdent`

--- a/tests/rules/msg-doc.js
+++ b/tests/rules/msg-doc.js
@@ -71,6 +71,11 @@ ruleTester.run( 'msg-doc', rule, {
 
 		'message = mw.msg(test ? "foo" : "bar")',
 
+		// Expressions are assumed safe unless they use string concatenation
+		'message = mw.msg( key )',
+		'message = mw.msg( config.key )',
+		'message = new mw.Message( key )',
+
 		'message = mw.msg(test ? (test2 ? "foo" : "bar") : (test2 ? "baz" : "quux"))',
 
 		'message = mw.msg("foo-bar")',
@@ -85,6 +90,8 @@ ruleTester.run( 'msg-doc', rule, {
 	],
 	invalid: [
 		'message = mw.msg( "foo-" + bar )',
+		'message = mw.msg( bar + baz )',
+		'message = mw.msg( key += suffix )',
 
 		'message = mw.msg( cond ? "baz" : "foo-" + bar )',
 		'message = new mw.Message( cond ? "baz" : "foo-" + bar )',


### PR DESCRIPTION
Most of our false positives are when a single variable
is passed into addClass/msg, e.g. from a function argument.

Very rarely do we see problematic string concatenation
being stored in a variable before later being passed to
one of these functions.
